### PR TITLE
Arch installer, and mugen-voice as its own pkgbase

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,13 +117,23 @@ jobs:
           check 'mugen-shell-*.pkg.tar.zst' 'usr/bin/mugen-shell-session'
           check 'mugen-shell-*.pkg.tar.zst' 'usr/share/wayland-sessions/mugen-shell.desktop'
           check 'mugen-shell-*.pkg.tar.zst' 'etc/pam.d/mugen-lock'
-          check 'mugen-voice-*.pkg.tar.zst' 'usr/share/mugen-voice/yurad.py'
           absent() {
             bsdtar tf $1 | grep -q "$2" && { echo "$1 ships an ignored file: $2" >&2; exit 1; }
             true
           }
           absent 'mugen-shell-*.pkg.tar.zst' 'user-overrides.lua'
           absent 'mugen-shell-*.pkg.tar.zst' 'test-shell.qml'
+
+      # Its own pkgbase, so the desktop build never downloads the 111MB voice model.
+      # -d because nothing here is compiled: the depends are runtime-only and one is AUR.
+      - name: Build and inspect mugen-voice
+        run: |
+          sudo -u builder sh -c 'cd arch/mugen-voice && makepkg -d --noconfirm'
+          cd arch/mugen-voice
+          bsdtar tf mugen-voice-*.pkg.tar.zst | grep -qx 'usr/share/mugen-voice/yurad.py' \
+            || { echo 'mugen-voice ships no yurad.py' >&2; exit 1; }
+          bsdtar tf mugen-voice-*.pkg.tar.zst | grep -q 'tts/vits-piper-en_US-lessac-high/.*onnx' \
+            || { echo 'mugen-voice ships no voice model' >&2; exit 1; }
 
       # The engine bundle is a few hundred MB, so CI only parses the recipe.
       - name: Parse the AivisSpeech PKGBUILD

--- a/README.en.md
+++ b/README.en.md
@@ -44,7 +44,7 @@ Try it without installing anything (Yura needs a model of your own before it wil
 nix build "github:tmy7533018/mugen-shell#nixosConfigurations.vm.config.system.build.vm" && ./result/bin/run-mugen-vm-vm
 ```
 
-Install steps and configuration are documented in [SETUP.en.md](SETUP.en.md). On Arch, the PKGBUILD in `arch/mugen-shell` is the entry point.
+Install steps and configuration are documented in [SETUP.en.md](SETUP.en.md). On Arch, `./install.sh` does the whole thing.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Yura はデスクトップの操作も可能です。「音量 30 にして」�
 nix build "github:tmy7533018/mugen-shell#nixosConfigurations.vm.config.system.build.vm" && ./result/bin/run-mugen-vm-vm
 ```
 
-インストール手順と設定については [SETUP.md](SETUP.md) にまとめました。Arch なら `arch/mugen-shell` の PKGBUILD から入ります。
+インストール手順と設定については [SETUP.md](SETUP.md) にまとめました。Arch なら `./install.sh` 一本で入ります。
 
 ---
 

--- a/SETUP.en.md
+++ b/SETUP.en.md
@@ -25,6 +25,27 @@ Needs **Hyprland 0.55 or newer**. Arch Linux installs from packages; on any othe
 
 ### Arch Linux
 
+```bash
+git clone https://github.com/tmy7533018/mugen-shell.git
+cd mugen-shell
+./install.sh
+```
+
+A menu lets you pick what goes in. Taking the defaults leaves you with a desktop you can log into.
+Read-aloud is off by default: it builds `onnxruntime` from source, which takes hours.
+
+To run it without the menu:
+
+```bash
+./install.sh --yes                      # the defaults
+./install.sh --with-voice --without-zsh # pick individually (--help lists them)
+```
+
+When it finishes, log out and pick **mugen-shell** from your display manager's session list.
+
+<details>
+<summary>Installing by hand instead</summary>
+
 **1. Install what the build needs**
 
 ```bash
@@ -53,11 +74,10 @@ The UI names `M PLUS 2` and `M PLUS 1 Code`, so the Nerd Fonts build (`ttf-mplus
 ```bash
 git clone https://github.com/tmy7533018/mugen-shell.git
 cd mugen-shell/arch/mugen-shell
-makepkg -s
-sudo pacman -U mugen-audio-*.pkg.tar.zst mugen-ai-*.pkg.tar.zst mugen-shell-*.pkg.tar.zst
+makepkg -si
 ```
 
-Do not use `makepkg -si`. This is a split package, so it also installs `mugen-voice`, which builds `python-sherpa-onnx` from source and takes over 30 minutes. Install read-aloud separately from [Read aloud](#read-aloud-optional).
+Read-aloud is a separate package. If you want it, see [Read aloud](#read-aloud-optional).
 
 **5. Log in**
 
@@ -73,7 +93,7 @@ sudo pacman -S --needed fcitx5 fcitx5-mozc fcitx5-gtk fcitx5-qt fcitx5-configtoo
 
 The session wrapper sets `XMODIFIERS` inside the session. For apps launched outside the compositor, add `XMODIFIERS=@im=fcitx` to `/etc/environment` as well.
 
-**Make the terminal match mugen-shell too (optional)**
+**Make the terminal match mugen-shell too**
 
 Gets you the starship prompt, fish-style completion and history, `ls` → `eza` aliases, and the fastfetch ASCII art splash.
 
@@ -87,6 +107,8 @@ Then add this one line to your own `~/.zshrc`:
 ```sh
 source /usr/share/mugen-shell/zsh/mugen-shell.zshrc
 ```
+
+</details>
 
 <details>
 <summary><b>NixOS</b></summary>
@@ -406,12 +428,12 @@ Yura can speak its replies: press the speaker icon on a reply in the panel.
 
 The default stack is Japanese-first but not Japanese-only (see *Running Yura's voice in another language* below). It sits on top of a running mugen-ai.
 
-**Arch Linux.** `makepkg` already built `mugen-voice` during the install, so install its dependencies and then that package. `python-sherpa-onnx` builds from source on the AUR and takes over 30 minutes:
+**Arch Linux.** `python-sherpa-onnx` builds from source on the AUR, and it builds `onnxruntime` with it, so expect hours:
 
 ```bash
 yay -S --needed python-sherpa-onnx python-sounddevice
-cd mugen-shell/arch/mugen-shell
-sudo pacman -U mugen-voice-*.pkg.tar.zst
+cd mugen-shell/arch/mugen-voice
+makepkg -si
 ```
 
 For a Japanese voice, add the AivisSpeech engine. Installing it is what switches the default voice over to it:

--- a/SETUP.md
+++ b/SETUP.md
@@ -8,6 +8,27 @@
 
 ### Arch Linux
 
+```bash
+git clone https://github.com/tmy7533018/mugen-shell.git
+cd mugen-shell
+./install.sh
+```
+
+入れるものをメニューで選べます。既定のまま進めればログインして使える状態になります。
+読み上げだけは `onnxruntime` のソースビルドで数時間かかるので、既定では入りません。
+
+非対話で走らせる場合:
+
+```bash
+./install.sh --yes                      # 既定のまま
+./install.sh --with-voice --without-zsh # 個別に指定 (--help で一覧)
+```
+
+終わったらログアウトして、ディスプレイマネージャのセッション一覧から **mugen-shell** を選んでください。
+
+<details>
+<summary>インストーラを使わず手で入れる</summary>
+
 **1. ビルドに要るものを入れる**
 
 ```bash
@@ -36,11 +57,10 @@ UI は `M PLUS 2` と `M PLUS 1 Code` を名指しするので、Nerd Fonts 版 
 ```bash
 git clone https://github.com/tmy7533018/mugen-shell.git
 cd mugen-shell/arch/mugen-shell
-makepkg -s
-sudo pacman -U mugen-audio-*.pkg.tar.zst mugen-ai-*.pkg.tar.zst mugen-shell-*.pkg.tar.zst
+makepkg -si
 ```
 
-`makepkg -si` は使わないでください。split package なので `mugen-voice` まで一緒に入り、`python-sherpa-onnx` のソースビルド (30 分超) を待たされます。読み上げは[読み上げ](#読み上げ-オプション)から別に入れられます。
+読み上げは別のパッケージです。要る場合は[読み上げ](#読み上げ-オプション)へ。
 
 **5. ログインする**
 
@@ -56,7 +76,7 @@ sudo pacman -S --needed fcitx5 fcitx5-mozc fcitx5-gtk fcitx5-qt fcitx5-configtoo
 
 セッション内の `XMODIFIERS` はセッションラッパーが設定します。コンポジタの外から起動するアプリのために、`/etc/environment` にも `XMODIFIERS=@im=fcitx` を書いておいてください。
 
-**ターミナルも mugen-shell の見た目にする (オプション)**
+**ターミナルも mugen-shell の見た目にする**
 
 starship のプロンプト、fish 風の補完と履歴、`ls` → `eza` のエイリアス、`fastfetch` の ASCII アート表示が入ります。
 
@@ -70,6 +90,8 @@ sudo pacman -S --needed zsh starship jp2a fastfetch eza bat ugrep \
 ```sh
 source /usr/share/mugen-shell/zsh/mugen-shell.zshrc
 ```
+
+</details>
 
 <details>
 <summary><b>NixOS</b></summary>
@@ -401,12 +423,12 @@ Yura の返事は、パネルのスピーカーアイコンを押すと読み上
 
 前提として mugen-ai が動いている必要があります。
 
-**Arch Linux.** インストールのときに `makepkg` が `mugen-voice` まで作ってあるので、依存を入れてからそれを入れます。`python-sherpa-onnx` は AUR からのソースビルドで、30 分以上かかります:
+**Arch Linux.** `python-sherpa-onnx` は AUR からのソースビルドで、`onnxruntime` も一緒に作るので数時間かかります:
 
 ```bash
 yay -S --needed python-sherpa-onnx python-sounddevice
-cd mugen-shell/arch/mugen-shell
-sudo pacman -U mugen-voice-*.pkg.tar.zst
+cd mugen-shell/arch/mugen-voice
+makepkg -si
 ```
 
 日本語の声が要る場合は、AivisSpeech エンジンも入れてください。既定の声がこのエンジンに切り替わります:

--- a/arch/mugen-shell/PKGBUILD
+++ b/arch/mugen-shell/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: tmy7533018 <baske3018@gmail.com>
 
 pkgbase=mugen-shell
-pkgname=(mugen-shell mugen-ai mugen-audio mugen-voice)
+pkgname=(mugen-shell mugen-ai mugen-audio)
 pkgver=0.1.0
 pkgrel=1
 pkgdesc='A Quickshell + Hyprland desktop with a 夢幻 aesthetic'
@@ -11,9 +11,6 @@ license=('MIT')
 # Split debug packages symlink across subpackages and land broken.
 options=('!debug')
 makedepends=('git' 'go' 'cmake' 'ninja' 'pkgconf' 'qt6-base' 'qt6-declarative' 'libcava')
-source=('vits-piper-en_US-lessac-high.tar.bz2::https://github.com/k2-fsa/sherpa-onnx/releases/download/tts-models/vits-piper-en_US-lessac-high.tar.bz2')
-sha256sums=('8619d204c7005866fe4f420181dfa79622af6a6222389f0b0818d2af31e0db0e')
-
 # Built from the surrounding checkout so a one-line fix needs no push.
 # Publishing to the AUR later means swapping this for a git source.
 _repo() { (cd "$startdir/../.." && pwd); }
@@ -121,24 +118,4 @@ package_mugen-shell() {
   install -Dm644 system/systemd/user/mugen-shell-session.target \
     "$pkgdir/usr/lib/systemd/user/mugen-shell-session.target"
   install -Dm644 LICENSE "$pkgdir/usr/share/licenses/mugen-shell/LICENSE"
-}
-
-package_mugen-voice() {
-  pkgdesc='Yura speech daemon for mugen-shell (read-aloud TTS)'
-  arch=('any')
-  depends=('python' 'python-sherpa-onnx' 'python-sounddevice' 'python-numpy'
-           'python-requests' 'mugen-ai')
-  optdepends=('aivisspeech-engine: Japanese TTS')
-  local repo; repo=$(_tree)
-
-  install -Dm644 "$repo/voice/yurad.py" "$pkgdir/usr/share/mugen-voice/yurad.py"
-  # yura/ is the pipeline; shipping yurad.py alone crashes on the first import.
-  cp -r "$repo/voice/yura" "$pkgdir/usr/share/mugen-voice/yura"
-
-  install -d "$pkgdir/usr/share/mugen-voice/tts"
-  cp -r "$srcdir/vits-piper-en_US-lessac-high" "$pkgdir/usr/share/mugen-voice/tts/"
-
-  install -Dm644 "$repo/system/systemd/user/yura-voice.service" \
-    "$pkgdir/usr/lib/systemd/user/yura-voice.service"
-  install -Dm644 "$repo/LICENSE" "$pkgdir/usr/share/licenses/mugen-voice/LICENSE"
 }

--- a/arch/mugen-shell/PKGBUILD
+++ b/arch/mugen-shell/PKGBUILD
@@ -68,6 +68,7 @@ package_mugen-ai() {
 package_mugen-shell() {
   # Only QML, scripts and assets.
   arch=('any')
+  # A new entry here needs its counterpart in nix/home-manager.nix; nothing checks the pair.
   depends=(
     'hyprland' 'quickshell' 'hypridle' 'hyprpolkitagent' 'mpvpaper' 'awww'
     'matugen' 'playerctl' 'wl-clipboard' 'cliphist' 'libnotify' 'grim' 'slurp'

--- a/arch/mugen-voice/.gitignore
+++ b/arch/mugen-voice/.gitignore
@@ -1,0 +1,5 @@
+src/
+pkg/
+*.pkg.tar.zst
+*.tar.bz2
+*.7z.001

--- a/arch/mugen-voice/PKGBUILD
+++ b/arch/mugen-voice/PKGBUILD
@@ -1,0 +1,44 @@
+# Maintainer: tmy7533018 <baske3018@gmail.com>
+
+pkgname=mugen-voice
+pkgver=0.1.0
+pkgrel=1
+pkgdesc='Yura speech daemon for mugen-shell (read-aloud TTS)'
+arch=('any')
+url='https://github.com/tmy7533018/mugen-shell'
+license=('MIT')
+depends=('python' 'python-sherpa-onnx' 'python-sounddevice' 'python-numpy'
+         'python-requests' 'mugen-ai')
+optdepends=('aivisspeech-engine: Japanese TTS')
+makedepends=('git')
+# Its own pkgbase, so the 111MB model is not downloaded by people who only want the desktop.
+source=('vits-piper-en_US-lessac-high.tar.bz2::https://github.com/k2-fsa/sherpa-onnx/releases/download/tts-models/vits-piper-en_US-lessac-high.tar.bz2')
+sha256sums=('8619d204c7005866fe4f420181dfa79622af6a6222389f0b0818d2af31e0db0e')
+
+# Built from the surrounding checkout so a one-line fix needs no push.
+_repo() { (cd "$startdir/../.." && pwd); }
+# Only what git tracks: the directories we copy also hold ignored personal files.
+_tree() { echo "$srcdir/tree"; }
+
+prepare() {
+  local repo; repo=$(_repo)
+  rm -rf "$(_tree)"
+  mkdir -p "$(_tree)"
+  # -C has to precede -T or GNU tar resolves the file list against the cwd instead.
+  git -C "$repo" ls-files -z | tar -C "$repo" -cf - --null -T - | tar -xf - -C "$(_tree)"
+}
+
+package() {
+  local repo; repo=$(_tree)
+
+  install -Dm644 "$repo/voice/yurad.py" "$pkgdir/usr/share/mugen-voice/yurad.py"
+  # yura/ is the pipeline; shipping yurad.py alone crashes on the first import.
+  cp -r "$repo/voice/yura" "$pkgdir/usr/share/mugen-voice/yura"
+
+  install -d "$pkgdir/usr/share/mugen-voice/tts"
+  cp -r "$srcdir/vits-piper-en_US-lessac-high" "$pkgdir/usr/share/mugen-voice/tts/"
+
+  install -Dm644 "$repo/system/systemd/user/yura-voice.service" \
+    "$pkgdir/usr/lib/systemd/user/yura-voice.service"
+  install -Dm644 "$repo/LICENSE" "$pkgdir/usr/share/licenses/mugen-voice/LICENSE"
+}

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,234 @@
+#!/usr/bin/env bash
+# Installs mugen-shell on Arch: the packages, then the pieces people differ on. Re-running is safe.
+set -euo pipefail
+
+repo=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+
+# AUR-only, so pacman cannot resolve them and the helper has to.
+aur_deps=(mpvpaper awww matugen ttf-mplus-git libcava)
+default_apps=(kitty thunar firefox)
+zsh_pkgs=(zsh starship jp2a fastfetch eza bat ugrep
+          zsh-syntax-highlighting zsh-autosuggestions zsh-history-substring-search)
+
+assume_yes=0
+
+say()  { printf '\n\033[1m==>\033[0m %s\n' "$1"; }
+warn() { printf '\033[33m  !\033[0m %s\n' "$1" >&2; }
+die()  { printf '\033[31m==> %s\033[0m\n' "$1" >&2; exit 1; }
+
+have()      { command -v "$1" > /dev/null 2>&1; }
+installed() { pacman -Qq "$1" > /dev/null 2>&1; }
+
+# Announce before the prompt appears, so a sudo password is never a surprise.
+as_root() {
+  printf '  \033[2msudo:\033[0m %s\n' "$1"; shift
+  sudo "$@"
+}
+
+preflight() {
+  [[ -f /etc/arch-release ]] || die "this installer is for Arch Linux"
+  [[ $EUID -ne 0 ]] || die "run as your normal user: makepkg refuses to build as root"
+  local missing=()
+  have git || missing+=(git)
+  have makepkg || missing+=(base-devel)
+  if (( ${#missing[@]} )); then
+    say "Installing build prerequisites"
+    as_root "install ${missing[*]}" pacman -S --needed --noconfirm "${missing[@]}"
+  fi
+}
+
+# Prefer the display manager already in charge; only offer SDDM when nothing is.
+dm_present() {
+  systemctl list-unit-files --no-legend 'display-manager.service' 2>/dev/null | grep -q . \
+    || [[ -e /etc/systemd/system/display-manager.service ]]
+}
+
+guess_ime_engine() {
+  # An engine that is already installed beats the locale: an English system with Japanese input is common.
+  local e
+  for e in mozc rime hangul; do
+    if installed "fcitx5-$e"; then echo "$e"; return; fi
+  done
+  case "${LC_CTYPE:-${LANG:-}}" in
+    ja_JP*) echo mozc ;;
+    ko_KR*) echo hangul ;;
+    zh_*)   echo rime ;;
+    *)      echo none ;;
+  esac
+}
+
+want_ime=1
+want_voice=0
+want_zsh=0
+want_apps=1
+want_dm=1
+ime_engine=$(guess_ime_engine)
+if [[ "$ime_engine" == none ]]; then want_ime=0; ime_engine=mozc; fi
+if dm_present; then want_dm=0; fi
+
+usage() {
+  cat <<'USAGE'
+usage: ./install.sh [--yes] [--with-X | --without-X] ...
+
+  --yes            take the defaults without showing the menu
+  --with-ime=ENGINE   mozc, rime or hangul (default: guessed from $LANG)
+  --with-X            X is one of: ime voice zsh apps dm
+  --without-X         the same names, turned off
+
+With no arguments the menu is shown.
+USAGE
+}
+
+while (( $# )); do
+  case "$1" in
+    --yes) assume_yes=1 ;;
+    --with-ime=*) want_ime=1; ime_engine=${1#*=} ;;
+    --with-ime)    want_ime=1   ;; --without-ime)   want_ime=0   ;;
+    --with-voice)  want_voice=1 ;; --without-voice) want_voice=0 ;;
+    --with-zsh)    want_zsh=1   ;; --without-zsh)   want_zsh=0   ;;
+    --with-apps)   want_apps=1  ;; --without-apps)  want_apps=0  ;;
+    --with-dm)     want_dm=1    ;; --without-dm)    want_dm=0    ;;
+    -h|--help) usage; exit 0 ;;
+    *) usage >&2; die "unknown option: $1" ;;
+  esac
+  # Any explicit choice means the caller knows what they want, so skip the menu.
+  [[ "$1" == --yes ]] || assume_yes=1
+  shift
+done
+
+mark() { if [[ ${!1} -eq 1 ]]; then printf 'x'; else printf ' '; fi; }
+
+menu() {
+  while :; do
+    printf '\n  \033[1mmugen-shell installer\033[0m\n\n'
+    printf '    1  [%s] %-14s fcitx5 + %s\n' "$(mark want_ime)"   'IME'          "$ime_engine"
+    printf '    2  [%s] %-14s mugen-voice + AivisSpeech (builds onnxruntime, hours)\n' "$(mark want_voice)" 'read-aloud'
+    printf '    3  [%s] %-14s starship, eza, fastfetch\n' "$(mark want_zsh)"  'zsh config'
+    printf '    4  [%s] %-14s %s\n' "$(mark want_apps)" 'default apps' "${default_apps[*]}"
+    if dm_present; then
+      printf '    5  [-] %-14s already configured\n' 'display mgr'
+    else
+      printf '    5  [%s] %-14s no display manager found\n' "$(mark want_dm)" 'SDDM'
+    fi
+    printf '\n  mugen-shell, mugen-ai and mugen-audio are always installed.\n'
+    printf '  \033[2mnumber to toggle, e to pick the IME engine, Enter to start, q to quit\033[0m\n\n  > '
+    local choice; read -r choice || choice=q
+    case "$choice" in
+      1) want_ime=$((1 - want_ime)) ;;
+      2) want_voice=$((1 - want_voice)) ;;
+      3) want_zsh=$((1 - want_zsh)) ;;
+      4) want_apps=$((1 - want_apps)) ;;
+      5) dm_present || want_dm=$((1 - want_dm)) ;;
+      e) printf '  engine (mozc/rime/hangul): '; read -r ime_engine ;;
+      "") return 0 ;;
+      q|Q) exit 0 ;;
+      *) warn "unknown choice: $choice" ;;
+    esac
+  done
+}
+
+ensure_aur_helper() {
+  for h in yay paru; do
+    if have "$h"; then aur=$h; return 0; fi
+  done
+  # paru-bin is built against a pinned libalpm and breaks on every pacman bump.
+  say "Building yay (no AUR helper found)"
+  local tmp; tmp=$(mktemp -d)
+  git clone --depth 1 https://aur.archlinux.org/yay.git "$tmp/yay"
+  (cd "$tmp/yay" && makepkg -si --noconfirm)
+  rm -rf "$tmp"
+  aur=yay
+}
+
+aur_install() {
+  local want=() p
+  for p in "$@"; do installed "$p" || want+=("$p"); done
+  (( ${#want[@]} )) || { printf '  already present: %s\n' "$*"; return 0; }
+  "$aur" -S --needed --noconfirm "${want[@]}"
+}
+
+pac_install() {
+  local want=() p
+  for p in "$@"; do installed "$p" || want+=("$p"); done
+  (( ${#want[@]} )) || { printf '  already present: %s\n' "$*"; return 0; }
+  as_root "install ${want[*]}" pacman -S --needed --noconfirm "${want[@]}"
+}
+
+build_core() {
+  say "Building mugen-shell, mugen-ai and mugen-audio"
+  (cd "$repo/arch/mugen-shell" && makepkg -sf --noconfirm)
+  # Only the three built here: read-aloud is its own pkgbase precisely so this stays cheap.
+  as_root "install the three built packages" \
+    pacman -U --noconfirm "$repo"/arch/mugen-shell/*.pkg.tar.zst
+
+  # pacman swaps the QML the running shell watches, and a reload landing mid-extraction fails.
+  if systemctl --user is-active --quiet mugen-shell.service 2> /dev/null; then
+    printf '  restarting the running bar onto the new files\n'
+    systemctl --user restart mugen-shell.service
+  fi
+}
+
+build_voice() {
+  say "Building read-aloud (this is the slow one)"
+  aur_install python-sherpa-onnx python-sounddevice
+  # -d: nothing is compiled here, and the runtime depends were just installed above.
+  (cd "$repo/arch/mugen-voice" && makepkg -df --noconfirm)
+  as_root "install mugen-voice" pacman -U --noconfirm "$repo"/arch/mugen-voice/*.pkg.tar.zst
+
+  say "Building the AivisSpeech engine (Japanese voice)"
+  (cd "$repo/arch/aivisspeech-engine" && makepkg -f --noconfirm)
+  as_root "install aivisspeech-engine" \
+    pacman -U --noconfirm "$repo"/arch/aivisspeech-engine/*.pkg.tar.zst
+}
+
+setup_ime() {
+  say "Installing the input method"
+  pac_install fcitx5 fcitx5-gtk fcitx5-qt fcitx5-configtool "fcitx5-$ime_engine"
+  # Apps started outside the compositor never see the session wrapper's XMODIFIERS.
+  local env_file=${MUGEN_ENV_FILE:-/etc/environment}   # overridable so the test can drive both branches
+  if ! grep -q '^XMODIFIERS=' "$env_file" 2> /dev/null; then
+    as_root "add XMODIFIERS to $env_file" \
+      sh -c "echo XMODIFIERS=@im=fcitx >> '$env_file'"
+  fi
+}
+
+setup_zsh() {
+  say "Installing the zsh configuration"
+  pac_install "${zsh_pkgs[@]}"
+  local line="source /usr/share/mugen-shell/zsh/mugen-shell.zshrc"
+  if [[ -f "$HOME/.zshrc" ]] && grep -qF "$line" "$HOME/.zshrc"; then
+    printf '  ~/.zshrc already sources it\n'
+  else
+    printf '%s\n' "$line" >> "$HOME/.zshrc"
+    printf '  appended to ~/.zshrc\n'
+  fi
+}
+
+setup_dm() {
+  say "Installing SDDM"
+  pac_install sddm
+  as_root "enable sddm" systemctl enable sddm.service
+}
+
+main() {
+  preflight
+  (( assume_yes )) || menu
+
+  ensure_aur_helper
+  say "Installing AUR dependencies"
+  aur_install "${aur_deps[@]}"
+
+  build_core
+  if (( want_apps ));  then say "Installing the default applications"; pac_install "${default_apps[@]}"; fi
+  if (( want_ime ));   then setup_ime; fi
+  if (( want_zsh ));   then setup_zsh; fi
+  if (( want_dm ));    then setup_dm; fi
+  if (( want_voice )); then build_voice; fi
+
+  say "Done"
+  printf '  Log out and pick \033[1mmugen-shell\033[0m from your display manager.\n'
+  if (( ! want_voice )); then printf '  Read-aloud was skipped; see SETUP.md if you want it later.\n'; fi
+  printf '  Personal Hyprland tweaks go in ~/.config/hypr/configs/user-overrides.lua\n\n'
+}
+
+main "$@"

--- a/nix/home-manager.nix
+++ b/nix/home-manager.nix
@@ -184,6 +184,7 @@ in
         lib.concatStringsSep ":" (import ./gi-typelib-dirs.nix pkgs);
     };
 
+    # A new entry here needs its counterpart in arch/mugen-shell/PKGBUILD; nothing checks the pair.
     home.packages =
       lib.optionals cfg.includeSystemDeps (
         with pkgs;


### PR DESCRIPTION
Opened to run CI before this reaches main: the workflow only triggers on `main` and pull requests, and the two things I cannot verify locally (`nix flake check`, the `archlinux:base-devel` job) are exactly what CI has.

- `arch/mugen-voice/` becomes its own pkgbase, so a desktop-only build no longer downloads the 111MB voice model. `makepkg -si` and `pacman -U *.pkg.tar.zst` are safe again.
- `install.sh` builds the packages and sets up the parts people differ on (IME, read-aloud, zsh, default apps, display manager), with `--yes` and `--with-*` / `--without-*` for scripting.
- SETUP and README lead with the installer; the manual steps move into a `<details>`.
- The Arch and Nix dependency lists now point at each other, since nothing checks the pair.

Verified locally: both pkgbases build and their contents were inspected, `dev/test-install.sh` covers 24 stubbed cases (checked that it goes red), and the installer was run for real on this machine twice.